### PR TITLE
Enable notifications and update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Add names of code owners for this repo
-* @niphilj @karl-g1
+* @buckd @karl-g1

--- a/build.toml
+++ b/build.toml
@@ -95,3 +95,6 @@ control_file = 'control_lvmm'
 payload_dir = 'Built\LVMM'
 install_destination = 'ni-paths-LV{labview_version}DIR'
 package_output_dir = 'Built'
+
+[notification]
+type = 'teams'


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-data-sharing-framework-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Enables build notifications to MS Teams
Updates codeowners

### Why should this Pull Request be merged?

Build failures will send notifications and codeowners have changed.

### What testing has been done?

None
