### PR TITLE
Document process for reserving error codes

### DIFF
--- a/docs/error_codes.md
+++ b/docs/error_codes.md
@@ -10,7 +10,9 @@ Individual custom devices may be assigned a portion of this range; this document
 
 A new error code range can be requested by creating a pull request editing this document.
 
-In general, custom devices should reserve either `25` or `50` error codes (per positive/negative range).
+In general, custom devices should reserve `25` error codes (per positive/negative range), leaving a gap of `25` from existing allocations.
+This allows custom devices which later need more error codes to reserve them contiguously, without over-allocating initially.
+
 Smaller allocations are allowed, although discouraged to prevent fragmenting the error code range.
 
 Error codes are allocated symmetrically for both positive and negative numbers.
@@ -21,7 +23,7 @@ Only the positive error codes are listed below, although the custom device is al
 
 | Begin    | End      | Custom Device |
 |----------|----------|---------------|
-| `732000` | `732049` | [Routing and Faulting](https://github.com/ni/niveristand-routing-and-faulting-custom-device) |
+| `732000` | `732024` | [Routing and Faulting](https://github.com/ni/niveristand-routing-and-faulting-custom-device) |
 | `732050` | `732074` | [SLSC Switch](https://github.com/ni/niveristand-routing-and-faulting-custom-device) |
-| `732075` | `732099` | [NI-SWITCH](https://github.com/ni/niveristand-routing-and-faulting-custom-device) |
-| `732100` | `732149` | [Scan Engine and EtherCAT](https://github.com/ni/niveristand-scan-engine-ethercat-custom-device) |
+| `732100` | `732124` | [NI-SWITCH](https://github.com/ni/niveristand-routing-and-faulting-custom-device) |
+| `732150` | `732174` | [Scan Engine and EtherCAT](https://github.com/ni/niveristand-scan-engine-ethercat-custom-device) |

--- a/docs/error_codes.md
+++ b/docs/error_codes.md
@@ -1,0 +1,27 @@
+# Custom Device Error Codes
+
+Historically custom devices have used error codes within the user-defined ranges.
+This has led to unintentional error code conflicts between different custom devices.
+
+To mitigate this, VeriStand custom devices now have a dedicated error code range: `732000` to `732999`, and `-732000` to `-732999`.
+Individual custom devices may be assigned a portion of this range; this document is the source of truth for these allocations.
+
+## Requesting an Error Code Range
+
+A new error code range can be requested by creating a pull request editing this document.
+
+In general, custom devices should reserve either `25` or `50` error codes (per positive/negative range).
+Smaller allocations are allowed, although discouraged to prevent fragmenting the error code range.
+
+Error codes are allocated symmetrically for both positive and negative numbers.
+
+## Allocated Error Codes
+
+Only the positive error codes are listed below, although the custom device is also allocated the corresponding negative range.
+
+| Begin    | End      | Custom Device |
+|----------|----------|---------------|
+| `732000` | `732049` | [Routing and Faulting](https://github.com/ni/niveristand-routing-and-faulting-custom-device) |
+| `732050` | `732074` | [SLSC Switch](https://github.com/ni/niveristand-routing-and-faulting-custom-device) |
+| `732075` | `732099` | [NI-SWITCH](https://github.com/ni/niveristand-routing-and-faulting-custom-device) |
+| `732100` | `732149` | [Scan Engine and EtherCAT](https://github.com/ni/niveristand-scan-engine-ethercat-custom-device) |


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-development-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Document the error code range reserved for custom devices and the process for requesting a new range.

Assign the Routing and Faulting custom device family and the Scan Engine and EtherCAT custom device error codes. 

### Why should this Pull Request be merged?

We're trying to instill order in the wild west.

### What testing has been done?

N/A
