### PR TITLE
Reserve error codes for the custom device development tools

### DIFF
--- a/docs/error_codes.md
+++ b/docs/error_codes.md
@@ -27,3 +27,4 @@ Only the positive error codes are listed below, although the custom device is al
 | `732050` | `732074` | [SLSC Switch](https://github.com/ni/niveristand-routing-and-faulting-custom-device) |
 | `732100` | `732124` | [NI-SWITCH](https://github.com/ni/niveristand-routing-and-faulting-custom-device) |
 | `732150` | `732174` | [Scan Engine and EtherCAT](https://github.com/ni/niveristand-scan-engine-ethercat-custom-device) |
+| `732200` | `732224` | [VeriStand Custom Device Development Tools](https://github.com/ni/niveristand-custom-device-development-tools) |


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-development-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Reserve error codes for this repo.

### Why should this Pull Request be merged?

We want to add error codes to new development (import/export).

### What testing has been done?

N/A
