### PR TITLE
Claim error code range for Ballard ARINC-429.

### DIFF
--- a/docs/error_codes.md
+++ b/docs/error_codes.md
@@ -28,3 +28,4 @@ Only the positive error codes are listed below, although the custom device is al
 | `732100` | `732124` | [NI-SWITCH](https://github.com/ni/niveristand-routing-and-faulting-custom-device) |
 | `732150` | `732174` | [Scan Engine and EtherCAT](https://github.com/ni/niveristand-scan-engine-ethercat-custom-device) |
 | `732200` | `732224` | [VeriStand Custom Device Development Tools](https://github.com/ni/niveristand-custom-device-development-tools) |
+| `732250` | `732274` | [Ballard ARINC-429](https://github.com/ni/niveristand-ballard-arinc429-custom-device) |


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-development-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This claims a range of 25 error codes for Ballard ARINC-429

### Why should this Pull Request be merged?

We are using this range of errors, and do not want overlap with other custom devices.

### What testing has been done?

NA
