### PR TITLE
reserve range 732350..732674 for Ballard MIL-STD 1553 CD

### DIFF
--- a/docs/error_codes.md
+++ b/docs/error_codes.md
@@ -30,3 +30,4 @@ Only the positive error codes are listed below, although the custom device is al
 | `732200` | `732224` | [VeriStand Custom Device Development Tools](https://github.com/ni/niveristand-custom-device-development-tools) |
 | `732250` | `732274` | [Ballard ARINC-429](https://github.com/ni/niveristand-ballard-arinc429-custom-device) |
 | `732300` | `732324` | [Encoding and Decoding Library](https://github.com/ni/niveristand-ballard-arinc429-custom-device/tree/main/Source/Encoding%20and%20Decoding) |
+| `732350` | `732374` | [Ballard MIL-STD 1553](https://github.com/ni/niveristand-ballard-milStd1553-custom-device) |


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-development-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Documents the error code range (732350..732674) reserved for the Ballard MIL-STD 1553 custom device.

### Why should this Pull Request be merged?

Each custom device reserves its own range of error codes, so unique error codes can provide detailed error source/descriptions to help users debug and fix errors during development and runtime.

### What testing has been done?

None.