### PR TITLE
Enable building for 64-bit

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,10 @@
 //Leave the above line alone.  It identifies this as a groovy script.
 @Library('vs-build-tools') _
 
-List<String> lvVersions = ['2018', '2019', '2020']
+def lvVersions = [
+  32 : ['2019', '2020'],
+  64 : ['2021']
+]
 
+diffPipeline(lvVersions)
 ni.vsbuild.PipelineExecutor.execute(this, 'vs_cd_build', lvVersions)
-diffPipeline(lvVersions[0])

--- a/build.toml
+++ b/build.toml
@@ -108,17 +108,17 @@ control_file = 'control'
 package_output_dir = 'Built'
 
 [package.payload_map]
-'Built\\Common' = 'ni-paths-LV{labview_version}DIR'
+'Built\\Common' = 'ni-paths-LV{labview_version}DIR{nipaths_64_bitness_suffix}'
 
 # TOML requires unique keys, but these resolve to the same path on disk
-'docs\\error_codes_files' = 'ni-paths-LV{labview_version}DIR\resource\errors\English'
-'.\docs\\error_codes_files' = 'ni-paths-NISHAREDDIR\LabVIEW Run-Time\{labview_version}\errors\English'
+'docs\\error_codes_files' = 'ni-paths-LV{labview_version}DIR{nipaths_64_bitness_suffix}\resource\errors\English'
+'.\docs\\error_codes_files' = 'ni-paths-NISHAREDDIR{nipaths_64_bitness_suffix}\LabVIEW Run-Time\{labview_version}\errors\English'
 
 [[package]]
 type = 'nipkg'
 control_file = 'control_lvmm'
 payload_dir = 'Built\LVMM'
-install_destination = 'ni-paths-LV{labview_version}DIR'
+install_destination = 'ni-paths-LV{labview_version}DIR{nipaths_64_bitness_suffix}'
 package_output_dir = 'Built'
 
 [notification]

--- a/control
+++ b/control
@@ -12,4 +12,4 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
 XB-DisplayName: VeriStand Custom Device Development Tools for LabVIEW {labview_version}
-Depends: {AUTOVERSION_ni-labview-{labview_version}-x86}, {ni-veristand-{labview_version}} (>= {labview_short_version}.0.0)
+Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-veristand-{labview_version} (>= {labview_short_version}.0.0)

--- a/control_lvmm
+++ b/control_lvmm
@@ -12,4 +12,4 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
 XB-DisplayName: LabVIEW Memory Management Tools for LabVIEW {labview_version}
-Depends: {AUTOVERSION_ni-labview-{labview_version}-x86}
+Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-development-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Fixes #44 
Drops LV 2017 and 2018 support.
Adds 2021 support.

### Why should this Pull Request be merged?

Beginning with VeriStand 2021, we need to support building for 64-bit. This change enables us to install the dev tools to 64-bit LabVIEW.

### What testing has been done?

None
