### PR TITLE
Reserve error codes for the Embedded Data Logger

### DIFF
--- a/docs/error_codes.md
+++ b/docs/error_codes.md
@@ -31,3 +31,4 @@ Only the positive error codes are listed below, although the custom device is al
 | `732250` | `732274` | [Ballard ARINC-429](https://github.com/ni/niveristand-ballard-arinc429-custom-device) |
 | `732300` | `732324` | [Encoding and Decoding Library](https://github.com/ni/niveristand-ballard-arinc429-custom-device/tree/main/Source/Encoding%20and%20Decoding) |
 | `732350` | `732374` | [Ballard MIL-STD 1553](https://github.com/ni/niveristand-ballard-milStd1553-custom-device) |
+| `732400` | `732424` | [Embedded Data Logger](https://github.com/ni/niveristand-embedded-data-logger-custom-device) |


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-development-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Reserve error codes for the Embedded Data Logger custom device.

### Why should this Pull Request be merged?

We want to return meaningful error codes from the EDL scripting API.

### What testing has been done?

N/A
