### PR TITLE
Only build 20.7 release branch for LabVIEW 2019 and 2020

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,8 +3,7 @@
 @Library('vs-build-tools') _
 
 def lvVersions = [
-  32 : ['2019', '2020'],
-  64 : ['2021']
+  32 : ['2019', '2020']
 ]
 
 diffPipeline(lvVersions)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-development-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Remove 2021 build to only build 20.7 release branch for LabVIEW 2019 and 2020.

### Why should this Pull Request be merged?

This is a cherry-pick to the release/20.7 branch to support the Ballard ARINC 429 and MIL-STD-1553 releases.

### What testing has been done?

Pending PR build.
