### PR TITLE
Requests error codes for NI-RDMA custom device

### DIFF
--- a/docs/error_codes.md
+++ b/docs/error_codes.md
@@ -32,3 +32,4 @@ Only the positive error codes are listed below, although the custom device is al
 | `732300` | `732324` | [Encoding and Decoding Library](https://github.com/ni/niveristand-ballard-arinc429-custom-device/tree/main/Source/Encoding%20and%20Decoding) |
 | `732350` | `732374` | [Ballard MIL-STD 1553](https://github.com/ni/niveristand-ballard-milStd1553-custom-device) |
 | `732400` | `732424` | [Embedded Data Logger](https://github.com/ni/niveristand-embedded-data-logger-custom-device) |
+| `732450` | `732474` | NI-RDMA |


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-development-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Requests error codes for the NI-RDMA custom device plugin.

### Why should this Pull Request be merged?

The NI-RDMA plugin will need a set of error codes for implementing custom RDMA custom device errors.

### What testing has been done?

No testing was done since this PR only modifies an MD file.
