### PR TITLE
Reserve error codes for AIM 429

### DIFF
--- a/docs/error_codes.md
+++ b/docs/error_codes.md
@@ -33,3 +33,4 @@ Only the positive error codes are listed below, although the custom device is al
 | `732350` | `732374` | [Ballard MIL-STD 1553](https://github.com/ni/niveristand-ballard-milStd1553-custom-device) |
 | `732400` | `732424` | [Embedded Data Logger](https://github.com/ni/niveristand-embedded-data-logger-custom-device) |
 | `732450` | `732474` | NI-RDMA |
+| `732500` | `732524` | [AIM ARINC-429](https://github.com/ni/niveristand-aim-arinc429-custom-device) |


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-development-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Reserves error code range for AIM 429 custom device.

### Why should this Pull Request be merged?

We need codes specific to this custom device.

### What testing has been done?

None
