### PR TITLE
Add 2023 to build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@
 
 def lvVersions = [
   32 : ['2019', '2020'],
-  64 : ['2021']
+  64 : ['2021', '2023']
 ]
 
 diffPipeline(lvVersions)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-development-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Create a LV 2023-based build of the dev tools

### Why should this Pull Request be merged?

We need 23.0 .nipkg's of this repo to provision build and test machines for in-dev VeriStand

### What testing has been done?

[Successful branch build](https://nijenkins/blue/organizations/jenkins/NI%2Fniveristand-custom-device-development-tools/detail/dev%2Ftest_23.0/1/pipeline/61) on a build node imaged with in-dev 2023 components
