### PR TITLE
Add error code range for SLSC EDS

### DIFF
--- a/docs/error_codes.md
+++ b/docs/error_codes.md
@@ -35,3 +35,4 @@ Only the positive error codes are listed below, although the custom device is al
 | `732450` | `732474` | NI-RDMA |
 | `732500` | `732524` | [AIM ARINC-429](https://github.com/ni/niveristand-aim-arinc429-custom-device) |
 | `732550` | `732574` | [AIM MIL-STD 1553](https://github.com/ni/niveristand-aim-milStd1553-custom-device) |
+| `732600` | `732624` | [SLSC EDS](https://github.com/ni/niveristand-slsc-eds-custom-device) |


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-development-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add an error code range for the SLSC EDS Custom Device

### Why should this Pull Request be merged?

The custom device is currently using random errors within the user-defined range.
Starting with https://github.com/ni/niveristand-slsc-eds-custom-device/pull/77, this moves errors into a range owned by Custom Devices.

### What testing has been done?

None
