### PR TITLE
Bump version to 24.0.0, add 2024 build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,6 +23,8 @@ stages:
           bitness: '64bit'
         - version: '2023'
           bitness: '64bit'
+        - version: '2024'
+          bitness: '64bit'
 
       codegenVis:
         - 'docs\error_codes_files\Copy Errors to Built Directory.vi'
@@ -83,7 +85,7 @@ stages:
           target: 'My Computer'
           buildSpec: 'Move Source'
 
-      releaseVersion: '23.5.0'
+      releaseVersion: '24.0.0'
       buildOutputLocation: 'Built'
       archiveLocation: '\\nirvana\Measurements\VeriStandAddons\niveristand-custom-device-development-tools'
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-development-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Bump the version to 24.0.0 and add a 2024 build. Keeping the 2020 build for now until we remove it fully from the build machines.

### Why should this Pull Request be merged?

Needed to get 2024 builds of custom devices.

### What testing has been done?

PR build.
