### PR TITLE
drop 2020 build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,8 +17,6 @@ stages:
   - template: azure-templates/stages.yml@niveristand-custom-device-build-tools
     parameters:
       lvVersionsToBuild:
-        - version: '2020'
-          bitness: '32bit'
         - version: '2021'
           bitness: '64bit'
         - version: '2023'


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-development-tools/blob/main/CONTRIBUTING.md).


### What does this Pull Request accomplish?

Removes 2020 from building.

### Why should this Pull Request be merged?

Don't need 2020 support anymore.

### What testing has been done?

None
