### PR TITLE
Bump version to 25.0.0 , update code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Add names of code owners for this repo
-* @skolthay @Raagul-s
+* @skolthay @gahegde-ni

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,6 +23,8 @@ stages:
           bitness: '64bit'
         - version: '2024'
           bitness: '64bit'
+        - version: '2025'
+          bitness: '64bit'
 
       codegenVis:
         - 'docs\error_codes_files\Copy Errors to Built Directory.vi'
@@ -83,7 +85,7 @@ stages:
           target: 'My Computer'
           buildSpec: 'Move Source'
 
-      releaseVersion: '24.0.0'
+      releaseVersion: '25.0.0'
       buildOutputLocation: 'Built'
       archiveLocation: '\\nirvana\Measurements\VeriStandAddons\niveristand-custom-device-development-tools'
 


### PR DESCRIPTION
- [ ] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-development-tools/blob/main/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-development-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Build CD dev tool on lv2025 also, and change release version to 25.0.0

### Why should this Pull Request be merged?

For development and ATS runs using latest LV (2025) 

### What testing has been done?

NA
