### PR TITLE
Exclude Custom Device Interface pkg for 2024 and 2025

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -185,6 +185,11 @@ stages:
           payloadMaps:
             - installLocation: 'ProgramFiles\NI\LVAddons\nivscustomdeviceexpress\1'
               payloadLocation: 'CDInterfaces'
+          exclusions:
+            - version: '2024'
+              bitness: '64bit'
+            - version: '2025'
+              bitness: '64bit'
 
   - template: azure-templates/linux-stage.yml@niveristand-custom-device-build-tools
     parameters:


### PR DESCRIPTION
- [ ] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-development-tools/blob/main/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-development-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This PR will exclude package generation for Custom Devices Interfaces for 2024 and 2025.

### Why should this Pull Request be merged?

We are only supporting Custom Devices Interfaces for 2026 with the CD Express Wizard

### What testing has been done?

TODO: Detail what testing has been done to ensure this submission meets requirements.
